### PR TITLE
add rubocop.yml when generating cookbooks

### DIFF
--- a/recipes/cookbook.rb
+++ b/recipes/cookbook.rb
@@ -42,6 +42,11 @@ cookbook_file "#{test_dir}/server_spec.rb" do
   action :create_if_missing
 end
 
+# rubocop
+cookbook_file "#{cookbooK_dir}/.rubocop.yml" do
+  source "rubocop.yml"
+end
+
 # TK
 %w(kitchen.yml kitchen.cloud.yml).each do |k|
   template "#{cookbook_dir}/.#{k}" do


### PR DESCRIPTION
The `rubocop.yml` already existed, we just never added it in the recipe.