### PR TITLE
Revert "Pass in chef_run instead of block"

### DIFF
--- a/templates/default/default_chefspec.rb.erb
+++ b/templates/default/default_chefspec.rb.erb
@@ -5,6 +5,6 @@ describe '<%= cookbook_name %>::<%= recipe_name %>' do
     ChefSpec::SoloRunner.new(CENTOS_7_OPTS).converge(described_recipe)
   end
   it 'converges successfully' do
-    expect(chef_run).to_not raise_error
+    expect { chef_run }.to_not raise_error
   end
 end


### PR DESCRIPTION
This reverts commit 1605538d4d51068d507b50be71f3890cb886defc.

I was wrong. It actually expects a block for raise_error