### PR TITLE
increase line length of our house style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,6 @@ AllCops:
     - '**/Cheffile'
   Exclude:
     - 'metadata.rb'
+
+LineLength:
+  Max: 120

--- a/files/default/rubocop.yml
+++ b/files/default/rubocop.yml
@@ -7,3 +7,6 @@ AllCops:
 
 Style/NumericLiteralPrefix:
   EnforcedOctalStyle: zero_only
+
+LineLength:
+  Max: 120


### PR DESCRIPTION
Especially when working with chef, a few random long lines of code are common in any given cookbook.

The 80 char limit does not make much sense in our modern environment, and we should consider increasing it substantially.

[Django](https://code.djangoproject.com/ticket/23395) moved from 79 to 119, allowing for viewing patches with plus and minus signs within a 120 char screen. However straw polling around the office found substantial objection to using an 'non-round number,' so I'm proposing 120 instead.