### PR TITLE
Remove the BlockLength check in rubocop

### DIFF
--- a/files/default/rubocop.yml
+++ b/files/default/rubocop.yml
@@ -10,3 +10,6 @@ Style/NumericLiteralPrefix:
 
 LineLength:
   Max: 120
+
+Metrics/BlockLength:
+  Enabled: false


### PR DESCRIPTION
This PR would remove the BlockLength check in rubocop. Alternatively, we could also change the max length. The default is 25. 

My reasoning is that whenever it comes up it seems like the answer is just to ignore it. So why not just remove it if we don't care. 

Of course this change will only be for new cookbooks. We would still need to change each repos rubocop.yml, if I understand how it works. 

@osuosl-cookbooks/chefs Thoughts? 