### PR TITLE
Fix line length on other cops

### DIFF
--- a/files/default/rubocop.yml
+++ b/files/default/rubocop.yml
@@ -8,8 +8,14 @@ AllCops:
 Style/NumericLiteralPrefix:
   EnforcedOctalStyle: zero_only
 
-LineLength:
+Metrics/LineLength:
   Max: 120
+
+Style/IfUnlessModifier:
+  MaxLineLength: 120
+
+Style/WhileUntilModifier:
+  MaxLineLength: 120
 
 Metrics/BlockLength:
   Enabled: false


### PR DESCRIPTION
Change line length to 120 on other cops that don't automatically bring in the global line length setting