### PR TITLE
Replace .rubocop.yml with symlink to repo's provided version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,1 @@
-AllCops:
-  Include:
-    - '**/Berksfile'
-    - '**/Cheffile'
-  Exclude:
-    - 'metadata.rb'
-
-LineLength:
-  Max: 120
+./files/default/rubocop.yml


### PR DESCRIPTION
Change local .rubocop.yml with a symlink to the version the repository provides, so that the one used by Rubocop in this repository is never out of date.

Already got feedback from @fahlmant, curious to hear what @ramereth thinks about it.