### PR TITLE
Updates Berkshelf before running the tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -124,7 +124,12 @@ task :unit do
     run_command('rspec')
 end
 
+desc 'Update Berkshelf'
+task :berks_update do
+      run_command('berks update')
+end
+
 desc 'Run all tests'
-task test: [:style, :lint, :unit]
+task test: [:berks_update, :style, :lint, :unit]
 
 task default: :test


### PR DESCRIPTION
This makes sure that rake passing/failing is reproduce-able behaviour throughout and not dependent on when the local berks were updated.

Discovered on  [osl-vpn-PR-12](https://github.com/osuosl-cookbooks/osl-vpn/pull/12)