### PR TITLE
Properly fix rubocop errors and remove rubocop ignore that is propagating

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,22 @@
-./files/default/rubocop.yml
+AllCops:
+  Include:
+    - '**/Berksfile'
+    - '**/Cheffile'
+  Exclude:
+    - 'metadata.rb'
+    - 'files/default/build_cookbook/test-fixture-recipe.rb'
+
+Style/NumericLiteralPrefix:
+  EnforcedOctalStyle: zero_only
+
+Metrics/LineLength:
+  Max: 120
+
+Style/IfUnlessModifier:
+  MaxLineLength: 120
+
+Style/WhileUntilModifier:
+  MaxLineLength: 120
+
+Metrics/BlockLength:
+  Enabled: false

--- a/files/default/rubocop.yml
+++ b/files/default/rubocop.yml
@@ -4,7 +4,6 @@ AllCops:
     - '**/Cheffile'
   Exclude:
     - 'metadata.rb'
-    - 'files/default/build_cookbook/test-fixture-recipe.rb'
 
 Style/NumericLiteralPrefix:
   EnforcedOctalStyle: zero_only


### PR DESCRIPTION
This line is propagating to all cookbooks, and isn't needed since the rubocop error is an easy fix. 