### PR TITLE
Remove Berksfile.lock to ensure we get the correct cookbooks on every run

### DIFF
--- a/files/default/Rakefile
+++ b/files/default/Rakefile
@@ -121,6 +121,7 @@ end
 
 desc 'Run RSpec (unit) tests'
 task :unit do
+    run_command('rm -f Berksfile.lock')
     run_command('rspec')
 end
 


### PR DESCRIPTION
This is safer than how we had been doing "berks update" in the Rakefile. This
fails if its the first time the cookbook it checked out.