### PR TITLE
Disable creating inspec "smoke test" files

### DIFF
--- a/recipes/app.rb
+++ b/recipes/app.rb
@@ -17,15 +17,15 @@ template "#{app_dir}/.kitchen.yml" do
 end
 
 # Inspec
-directory "#{app_dir}/test/smoke/default" do
-  recursive true
-end
-
-template "#{app_dir}/test/smoke/default/default_test.rb" do
-  source 'inspec_default_test.rb.erb'
-  helpers(ChefDK::Generator::TemplateHelper)
-  action :create_if_missing
-end
+# directory "#{app_dir}/test/smoke/default" do
+#   recursive true
+# end
+#
+# template "#{app_dir}/test/smoke/default/default_test.rb" do
+#   source 'inspec_default_test.rb.erb'
+#   helpers(ChefDK::Generator::TemplateHelper)
+#   action :create_if_missing
+# end
 
 # README
 template "#{app_dir}/README.md" do

--- a/recipes/cookbook.rb
+++ b/recipes/cookbook.rb
@@ -64,15 +64,15 @@ template "#{cookbook_dir}/.kitchen.yml" do
 end
 
 # Inspec
-directory "#{cookbook_dir}/test/smoke/default" do
-  recursive true
-end
-
-template "#{cookbook_dir}/test/smoke/default/default_test.rb" do
-  source 'inspec_default_test.rb.erb'
-  helpers(ChefDK::Generator::TemplateHelper)
-  action :create_if_missing
-end
+# directory "#{cookbook_dir}/test/smoke/default" do
+#   recursive true
+# end
+#
+# template "#{cookbook_dir}/test/smoke/default/default_test.rb" do
+#   source 'inspec_default_test.rb.erb'
+#   helpers(ChefDK::Generator::TemplateHelper)
+#   action :create_if_missing
+# end
 
 # Chefspec
 directory "#{cookbook_dir}/spec/unit/recipes" do

--- a/recipes/recipe.rb
+++ b/recipes/recipe.rb
@@ -5,8 +5,8 @@ recipe_path = File.join(cookbook_dir, 'recipes', "#{context.new_file_basename}.r
 spec_helper_path = File.join(cookbook_dir, 'spec', 'spec_helper.rb')
 spec_dir = File.join(cookbook_dir, 'spec', 'unit', 'recipes')
 spec_path = File.join(spec_dir, "#{context.new_file_basename}_spec.rb")
-inspec_dir = File.join(cookbook_dir, 'test', 'smoke', 'default')
-inspec_path = File.join(inspec_dir, "#{context.new_file_basename}.rb")
+# inspec_dir = File.join(cookbook_dir, 'test', 'smoke', 'default')
+# inspec_path = File.join(inspec_dir, "#{context.new_file_basename}.rb")
 serverspec_dir = File.join(cookbook_dir, 'test', 'integration', context.new_file_basename, 'serverspec')
 serverspec_path = File.join(serverspec_dir, "#{context.new_file_basename}_spec.rb")
 
@@ -51,15 +51,15 @@ cookbook_file serverspec_path do
 end
 
 # Inspec
-directory inspec_dir do
-  recursive true
-end
-
-template inspec_path do
-  source 'inspec_default_test.rb.erb'
-  helpers(ChefDK::Generator::TemplateHelper)
-  action :create_if_missing
-end
+# directory inspec_dir do
+#   recursive true
+# end
+#
+# template inspec_path do
+#   source 'inspec_default_test.rb.erb'
+#   helpers(ChefDK::Generator::TemplateHelper)
+#   action :create_if_missing
+# end
 
 # Recipe
 template recipe_path do

--- a/spec/unit/recipes/cookbook_spec.rb
+++ b/spec/unit/recipes/cookbook_spec.rb
@@ -24,7 +24,6 @@ describe 'code_generator::cookbook' do
     attributes
     recipes
     spec/unit/recipes
-    test/smoke/default
     test/integration/default/serverspec
   ).each do |d|
     it "creates #{base_dir}/#{d} directory" do
@@ -148,7 +147,7 @@ issues'$},
     end
   end
   it do
-    expect(chef_run).to create_template_if_missing('/tmp/test-cookbook/test/smoke/default/default_test.rb')
+    expect(chef_run).to_not create_template_if_missing('/tmp/test-cookbook/test/smoke/default/default_test.rb')
   end
   describe File.join(base_dir, 'recipes', 'default.rb') do
     let(:file) do

--- a/spec/unit/recipes/recipe_spec.rb
+++ b/spec/unit/recipes/recipe_spec.rb
@@ -89,6 +89,6 @@ describe 'code_generator::recipe' do
     ))
   end
   it do
-    expect(chef_run).to create_template_if_missing('/tmp/test-cookbook/test/smoke/default/foo.rb')
+    expect(chef_run).to_not create_template_if_missing('/tmp/test-cookbook/test/smoke/default/foo.rb')
   end
 end


### PR DESCRIPTION
We don't need these currently and the new structure is going to be different
anyway.