### PR TITLE
Specify inspec verifier in cookbooks' .kitchen.yml

### DIFF
--- a/spec/unit/recipes/cookbook_spec.rb
+++ b/spec/unit/recipes/cookbook_spec.rb
@@ -132,6 +132,9 @@ issues'$},
   describe File.join(base_dir, 'recipes', '.kitchen.yml') do
     let(:file) { chef_run.template(File.join(base_dir, '.kitchen.yml')) }
     it do
+      expect(chef_run).to render_file(file.name).with_content(/^verifier:\n  name: inspec$/)
+    end
+    it do
       expect(chef_run).to render_file(file.name).with_content(/- recipe\[test-cookbook::default\]$/)
     end
   end

--- a/templates/default/kitchen.yml.erb
+++ b/templates/default/kitchen.yml.erb
@@ -1,4 +1,7 @@
 ---
+verifier:
+  name: inspec
+
 suites:
   - name: default
     run_list:


### PR DESCRIPTION
This is necessary unless we want to specify the verifier in our global kitchen configuration (which would create the opposite problem for serverspec).

If you do `kitchen verify` on a cookbook using InSpec without specifying the verifier it defaults to ServerSpec, which results in an error about not being able to resolve the dependency `busser-inspec` (a gem that does not exist).