### PR TITLE
Update fauxhai platform versions used with ChefSpec

### DIFF
--- a/templates/default/spec_helper.rb.erb
+++ b/templates/default/spec_helper.rb.erb
@@ -13,15 +13,9 @@ CENTOS_6 = {
   version: '6.9',
 }.freeze
 
-DEBIAN_8 = {
-  platform: 'debian',
-  version: '8.9',
-}.freeze
-
 ALL_PLATFORMS = [
   CENTOS_6,
   CENTOS_7,
-  DEBIAN_8,
 ].freeze
 
 RSpec.configure do |config|

--- a/templates/default/spec_helper.rb.erb
+++ b/templates/default/spec_helper.rb.erb
@@ -5,17 +5,17 @@ ChefSpec::Coverage.start! { add_filter '<%= cookbook_name %>' }
 
 CENTOS_7 = {
   platform: 'centos',
-  version: '7.2.1511',
+  version: '7.4.1708',
 }.freeze
 
 CENTOS_6 = {
   platform: 'centos',
-  version: '6.8',
+  version: '6.9',
 }.freeze
 
 DEBIAN_8 = {
   platform: 'debian',
-  version: '8.6',
+  version: '8.9',
 }.freeze
 
 ALL_PLATFORMS = [


### PR DESCRIPTION
We're using version 5.6.0 of Fauxhai and can be using newer platform versions with ChefSpec according to: https://github.com/chefspec/fauxhai/blob/v5.6.0/PLATFORMS.md

This fixes a deprecation warning about Debian 8.6:
>WARNING: Fauxhai platform data for debian 8.6 is deprecated and will be removed in the 6.0 release 3/2018. A list of available platforms is available at https://github.com/chefspec/fauxhai/blob/master/PLATFORMS.md

@osuosl-cookbooks/chefs Also, since we're migrating workstations to Debian 9, should we consider adding that as a default? Or replacing Debian 8?