### PR TITLE
Create basic resource instead of empty file

### DIFF
--- a/spec/unit/recipes/resource_spec.rb
+++ b/spec/unit/recipes/resource_spec.rb
@@ -25,6 +25,7 @@ describe 'code_generator::resource' do
     end
     [
       /^resource_name :test_cookbook_foo$/,
+      /^provides :test_cookbook_foo$/,
       /^default_action :create$/,
       /^property :foo, String, default: 'Example property.'$/,
       /^action :create do$/,

--- a/spec/unit/recipes/resource_spec.rb
+++ b/spec/unit/recipes/resource_spec.rb
@@ -1,0 +1,38 @@
+require_relative '../../spec_helper'
+
+describe 'code_generator::resource' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(CENTOS_8).converge(described_recipe)
+  end
+  include_context 'common_stubs'
+  base_dir = '/tmp/test-cookbook'
+  before do
+    ChefCLI::Generator.add_attr_to_context(:recipe_name, 'foo')
+    ChefCLI::Generator.add_attr_to_context(:new_file_basename, 'foo')
+  end
+
+  it 'converges successfully' do
+    expect { chef_run }.to_not raise_error
+  end
+
+  it "creates #{base_dir}/resources directory" do
+    expect(chef_run).to create_directory(File.join(base_dir, 'resources'))
+  end
+
+  describe File.join(base_dir, 'resources', 'foo.rb') do
+    let(:file) do
+      chef_run.template(File.join(base_dir, 'resources', 'foo.rb'))
+    end
+    [
+      /^resource_name :test_cookbook_foo$/,
+      /^default_action :create$/,
+      /^property :foo, String, default: 'Example property.'$/,
+      /^action :create do$/,
+    ].each do |line|
+      it do
+        expect(chef_run).to render_file(file.name)
+          .with_content(line)
+      end
+    end
+  end
+end

--- a/spec/unit/recipes/resource_spec.rb
+++ b/spec/unit/recipes/resource_spec.rb
@@ -26,8 +26,9 @@ describe 'code_generator::resource' do
     [
       /^resource_name :test_cookbook_foo$/,
       /^provides :test_cookbook_foo$/,
+      %r{# INFO: example property -- see https://docs.chef.io/custom_resources/},
+      /^# property :foo, String, default: 'bar', description: 'Example property.'$/,
       /^default_action :create$/,
-      /^property :foo, String, default: 'Example property.'$/,
       /^action :create do$/,
     ].each do |line|
       it do

--- a/templates/default/resource.rb.erb
+++ b/templates/default/resource.rb.erb
@@ -2,7 +2,8 @@ resource_name :<%= cookbook_name.gsub('-', '_') %>_<%= recipe_name %>
 provides :<%= cookbook_name.gsub('-', '_') %>_<%= recipe_name %>
 default_action :create
 
-property :foo, String, default: 'Example property.'
+# INFO: example property -- see https://docs.chef.io/custom_resources/
+# property :foo, String, default: 'bar', description: 'Example property.'
 
 action :create do
   # do things

--- a/templates/default/resource.rb.erb
+++ b/templates/default/resource.rb.erb
@@ -1,4 +1,5 @@
 resource_name :<%= cookbook_name.gsub('-', '_') %>_<%= recipe_name %>
+provides :<%= cookbook_name.gsub('-', '_') %>_<%= recipe_name %>
 default_action :create
 
 property :foo, String, default: 'Example property.'

--- a/templates/default/resource.rb.erb
+++ b/templates/default/resource.rb.erb
@@ -1,1 +1,8 @@
-# To learn more about Custom Resources, see https://docs.chef.io/custom_resources/
+resource_name :<%= cookbook_name.gsub('-', '_') %>_<%= recipe_name %>
+default_action :create
+
+property :foo, String, default: 'Example property.'
+
+action :create do
+  # do things
+end


### PR DESCRIPTION
The upstream default resource template is a blank file with only a comment linking to the docs. This PR changes this template to generate a basic resource skeleton with the name, default action, and action block.