### PR TITLE
Generate a Jenkinsfile in new cookbooks

### DIFF
--- a/files/default/Jenkinsfile
+++ b/files/default/Jenkinsfile
@@ -1,0 +1,2 @@
+@Library('osl-pipelines') _
+oslCookbookCI()

--- a/files/default/chefignore
+++ b/files/default/chefignore
@@ -61,6 +61,7 @@ Dangerfile
 examples/*
 features/*
 Guardfile
+Jenkinsfile
 kitchen.yml*
 mlc_config.json
 Procfile

--- a/recipes/cookbook.rb
+++ b/recipes/cookbook.rb
@@ -77,6 +77,12 @@ cookbook_file "#{cookbook_dir}/.rubocop.yml" do
   action :create_if_missing
 end
 
+# Jenkinsfile: the osuosl-cookbooks org folder on Jenkins only builds repos
+# that contain one
+cookbook_file "#{cookbook_dir}/Jenkinsfile" do
+  action :create_if_missing
+end
+
 # LICENSE
 template "#{cookbook_dir}/LICENSE" do
   helpers(ChefCLI::Generator::TemplateHelper)


### PR DESCRIPTION
New cookbooks now scaffold the two-line Jenkinsfile that the `osuosl-cookbooks` organization folder on Jenkins looks for:

```groovy
@Library('osl-pipelines') _
oslCookbookCI()
```

- `create_if_missing`, like the other scaffolding, so re-runs don't clobber a customized one
- added to the generated `chefignore` so it is never bundled into cookbook uploads

Part of the label-driven automation rollout (osuosl-cookbooks/osl-jenkins#251, osuosl/cookbook-pipelines#3); harmless to merge any time — the Jenkinsfile only takes effect once the org folder exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)